### PR TITLE
Replace return Error(format_err!(...)) with bail!(...)

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -30,7 +30,7 @@ impl Connector {
             let ret = ReturnCode::from(yubihsm_sys::yh_connect_best(&mut this, 1, ptr::null_mut()));
 
             if ret != ReturnCode::Success {
-                return Err(format_err!("failed to connect: {}", ret));
+                bail!("failed to connect: {}", ret);
             }
         }
 
@@ -70,7 +70,7 @@ impl Connector {
             ));
 
             if ret != ReturnCode::Success {
-                return Err(format_err!("failed to create session: {}", ret));
+                bail!("failed to create session: {}", ret);
             }
 
             context.set_len(YH_CONTEXT_LEN as usize);
@@ -82,7 +82,7 @@ impl Connector {
             ));
 
             if ret != ReturnCode::Success {
-                return Err(format_err!("failed to authenticate session: {}", ret));
+                bail!("failed to authenticate session: {}", ret);
             }
         }
 
@@ -113,7 +113,7 @@ impl Connector {
             ));
 
             if ret != ReturnCode::Success {
-                return Err(format_err!("failed to get device info: {}", ret));
+                bail!("failed to get device info: {}", ret);
             }
 
             algorithms.set_len(algorithm_count);

--- a/src/session.rs
+++ b/src/session.rs
@@ -67,11 +67,11 @@ impl Session {
             ));
 
             if ret != ReturnCode::Success {
-                return Err(format_err!("yh_util_get_random failed: {}", ret));
+                bail!("yh_util_get_random failed: {}", ret);
             }
 
             if out_size != len {
-                return Err(format_err!("data sizes didn't match"));
+                bail!("data sizes didn't match");
             }
 
             out.set_len(out_size);
@@ -100,7 +100,7 @@ impl Session {
             ));
 
             if ret != ReturnCode::Success {
-                return Err(format_err!("couldn't sign_ecdsa: {}", ret));
+                bail!("couldn't sign_ecdsa: {}", ret);
             }
 
             out.set_len(out_size);
@@ -129,7 +129,7 @@ impl Session {
             ));
 
             if ret != ReturnCode::Success {
-                return Err(format_err!("couldn't sign_eddsa: {}", ret));
+                bail!("couldn't sign_eddsa: {}", ret);
             }
 
             out.set_len(out_size);
@@ -164,7 +164,7 @@ impl Session {
             ));
 
             if ret != ReturnCode::Success {
-                return Err(format_err!("couldn't sign_pkcs1v1_5: {}", ret));
+                bail!("couldn't sign_pkcs1v1_5: {}", ret);
             }
 
             out.set_len(out_size);
@@ -201,7 +201,7 @@ impl Session {
             ));
 
             if ret != ReturnCode::Success {
-                return Err(format_err!("couldn't sign_pss: {}", ret));
+                bail!("couldn't sign_pss: {}", ret);
             }
 
             out.set_len(out_size);

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,7 +14,7 @@ pub struct Domain(pub(crate) u8);
 impl Domain {
     pub fn new(domain: u8) -> Result<Domain, Error> {
         if domain < 1 || domain > 16 {
-            return Err(format_err!("invalid domain"));
+            bail!("invalid domain");
         }
 
         Ok(Domain(domain))

--- a/src/yubihsm.rs
+++ b/src/yubihsm.rs
@@ -27,7 +27,7 @@ impl Yubihsm {
         });
 
         if ret != yh_rc_YHR_SUCCESS {
-            return Err(format_err!("yh_init returned {}", ret));
+            bail!("yh_init returned {}", ret);
         }
 
         Ok(Yubihsm {
@@ -46,7 +46,7 @@ impl Yubihsm {
             ));
 
             if ret != ReturnCode::Success {
-                return Err(format_err!("couldn't create connector: {}", ret));
+                bail!("couldn't create connector: {}", ret);
             }
         }
 


### PR DESCRIPTION
Originally in #7 I forgot to `#[macro_use]` when importing `failure`.

`failure` does provide a `bail!(...)` macro equivalent to `error-chain`'s. This switches back to using it.