### PR TITLE
nix: add nix-shell derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,21 @@
+let
+  moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  nixpkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
+in
+  with nixpkgs;
+  clangStdenv.mkDerivation {
+    name = "libyubihsm";
+    buildInputs = [
+      autoconf
+      automake
+      cmake
+      gettext
+      glibc
+      protobuf
+      rustChannels.stable.rust
+    ];
+
+    shellHook = ''
+      export LIBCLANG_PATH="${llvmPackages.clang-unwrapped.lib}/lib"
+    '';
+  }


### PR DESCRIPTION
This can be used by running the following on any system with Nix:

    nix-shell --run 'cargo build'