### PR TITLE
Add wrappers for list_objects and get_object

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -35,8 +35,8 @@ macro_rules! generate_key {
         ) -> Result<(), Error> {
             let mut key_id_ptr = key_id;
             let c_label = CString::new(label)?;
-            let lib_domains = DomainParam::from(Vec::from(domains));
-            let lib_caps = yh_capabilities::from(Vec::from(capabilities));
+            let lib_domains = DomainParam::from(domains);
+            let lib_caps = yh_capabilities::from(capabilities);
 
             unsafe {
                 match ReturnCode::from(yubihsm_sys::$yh_func(
@@ -289,9 +289,9 @@ impl Session {
     ) -> Result<(), Error> {
         let mut key_id_ptr = key_id;
         let c_label = CString::new(label)?;
-        let lib_domains = DomainParam::from(Vec::from(domains));
-        let lib_caps = yh_capabilities::from(Vec::from(capabilities));
-        let lib_delegated_caps = yh_capabilities::from(Vec::from(delegated_capabilities));
+        let lib_domains = DomainParam::from(domains);
+        let lib_caps = yh_capabilities::from(capabilities);
+        let lib_delegated_caps = yh_capabilities::from(delegated_capabilities);
 
         unsafe {
             match ReturnCode::from(yubihsm_sys::yh_util_generate_key_wrap(
@@ -320,8 +320,8 @@ impl Session {
     ) -> Result<(), Error> {
         let mut key_id_ptr = key_id;
         let c_label = CString::new(label)?;
-        let lib_domains = DomainParam::from(Vec::from(domains));
-        let lib_caps = yh_capabilities::from(Vec::from(capabilities));
+        let lib_domains = DomainParam::from(domains);
+        let lib_caps = yh_capabilities::from(capabilities);
 
         unsafe {
             match ReturnCode::from(yubihsm_sys::yh_util_import_key_ec(
@@ -350,8 +350,8 @@ impl Session {
     ) -> Result<(), Error> {
         let mut key_id_ptr = key_id;
         let c_label = CString::new(label)?;
-        let lib_domains = DomainParam::from(Vec::from(domains));
-        let lib_caps = yh_capabilities::from(Vec::from(capabilities));
+        let lib_domains = DomainParam::from(domains);
+        let lib_caps = yh_capabilities::from(capabilities);
 
         unsafe {
             match ReturnCode::from(yubihsm_sys::yh_util_import_key_ed(
@@ -380,8 +380,8 @@ impl Session {
     ) -> Result<(), Error> {
         let mut key_id_ptr = key_id;
         let c_label = CString::new(label)?;
-        let lib_domains = DomainParam::from(Vec::from(domains));
-        let lib_caps = yh_capabilities::from(Vec::from(capabilities));
+        let lib_domains = DomainParam::from(domains);
+        let lib_caps = yh_capabilities::from(capabilities);
 
         unsafe {
             match ReturnCode::from(yubihsm_sys::yh_util_import_key_hmac(
@@ -414,8 +414,8 @@ impl Session {
     ) -> Result<(), Error> {
         let mut key_id_ptr = key_id;
         let c_label = CString::new(label)?;
-        let lib_domains = DomainParam::from(Vec::from(domains));
-        let lib_caps = yh_capabilities::from(Vec::from(capabilities));
+        let lib_domains = DomainParam::from(domains);
+        let lib_caps = yh_capabilities::from(capabilities);
 
         unsafe {
             match ReturnCode::from(yubihsm_sys::yh_util_import_key_rsa(
@@ -448,9 +448,9 @@ impl Session {
     ) -> Result<(), Error> {
         let mut key_id_ptr = key_id;
         let c_label = CString::new(label)?;
-        let lib_domains = DomainParam::from(Vec::from(domains));
-        let lib_caps = yh_capabilities::from(Vec::from(capabilities));
-        let lib_delegated_caps = yh_capabilities::from(Vec::from(delegated_capabilities));
+        let lib_domains = DomainParam::from(domains);
+        let lib_caps = yh_capabilities::from(capabilities);
+        let lib_delegated_caps = yh_capabilities::from(delegated_capabilities);
 
         unsafe {
             match ReturnCode::from(yubihsm_sys::yh_util_import_key_wrap(
@@ -483,9 +483,9 @@ impl Session {
         let c_label = CString::new(label)?;
         let c_pass = CString::new(password)?;
         let c_pass_slice = c_pass.as_bytes();
-        let lib_domains = DomainParam::from(Vec::from(domains));
-        let lib_caps = yh_capabilities::from(Vec::from(capabilities));
-        let lib_delegated_caps = yh_capabilities::from(Vec::from(delegated_capabilities));
+        let lib_domains = DomainParam::from(domains);
+        let lib_caps = yh_capabilities::from(capabilities);
+        let lib_delegated_caps = yh_capabilities::from(delegated_capabilities);
 
         unsafe {
             match ReturnCode::from(yubihsm_sys::yh_util_import_authkey(
@@ -515,8 +515,8 @@ impl Session {
     ) -> Result<(), Error> {
         let mut obj_id_ptr = object_id;
         let c_label = CString::new(label)?;
-        let lib_domains = DomainParam::from(Vec::from(domains));
-        let lib_caps = yh_capabilities::from(Vec::from(capabilities));
+        let lib_domains = DomainParam::from(domains);
+        let lib_caps = yh_capabilities::from(capabilities);
 
         unsafe {
             match ReturnCode::from(yubihsm_sys::yh_util_import_opaque(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,11 +15,6 @@
 use types::*;
 
 #[test]
-fn domain_to_string() {
-    assert_eq!(String::from("1"), String::from(Domain(1)));
-}
-
-#[test]
 fn new_domain() {
     assert_eq!(Domain(1), Domain::new(1).unwrap());
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,7 +31,7 @@ fn domain_domainparam() {
 #[test]
 fn domains_to_domainparam() {
     let orig_domains = vec![Domain(1), Domain(3)];
-    let domain_param = DomainParam::from(orig_domains.clone());
+    let domain_param = DomainParam::from(&orig_domains.clone());
     let new_domains: Vec<Domain> = domain_param.into();
     assert_eq!(new_domains.len(), 2);
     assert_eq!(orig_domains, new_domains);

--- a/src/types.rs
+++ b/src/types.rs
@@ -106,6 +106,7 @@ impl From<DomainParam> for Vec<Domain> {
             cstring
                 .to_string_lossy()
                 .split(':')
+                .filter(|d| *d != "")
                 .map(|d| d.parse::<u8>().unwrap())
                 .map(|d| Domain::new(d).unwrap())
                 .collect()

--- a/src/types.rs
+++ b/src/types.rs
@@ -43,9 +43,9 @@ impl From<Domain> for DomainParam {
     }
 }
 
-impl<T> From<T> for DomainParam
+impl<'a, T> From<T> for DomainParam
 where
-    T: AsRef<[Domain]> + IntoIterator<Item = Domain>,
+    T: IntoIterator<Item = &'a Domain>,
 {
     fn from(doms: T) -> Self {
         let mut out: u16 = 0;
@@ -500,7 +500,13 @@ pub enum Capability {
 
 impl From<Capability> for String {
     fn from(cap: Capability) -> Self {
-        match cap {
+        String::from(&cap)
+    }
+}
+
+impl<'a> From<&'a Capability> for String {
+    fn from(cap: &'a Capability) -> Self {
+        match *cap {
             Capability::GetOpaque => String::from("get_opaque"),
             Capability::PutOpaque => String::from("put_opaque"),
             Capability::PutAuthKey => String::from("put_authkey"),
@@ -628,9 +634,9 @@ impl From<Capability> for yh_capabilities {
     }
 }
 
-impl<T> From<T> for yh_capabilities
+impl<'a, T> From<T> for yh_capabilities
 where
-    T: AsRef<[Capability]> + IntoIterator<Item = Capability>,
+    T: IntoIterator<Item = &'a Capability>,
 {
     fn from(caps: T) -> Self {
         let joined_caps = caps.into_iter()

--- a/src/types.rs
+++ b/src/types.rs
@@ -495,6 +495,7 @@ pub enum Capability {
     DeleteHmacKey,
     DeleteTemplate,
     DeleteOtpAeadKey,
+    Unknown,
 }
 
 impl From<Capability> for String {
@@ -546,6 +547,64 @@ impl From<Capability> for String {
             Capability::DeleteHmacKey => String::from("delete_hmac_key"),
             Capability::DeleteTemplate => String::from("delete_template"),
             Capability::DeleteOtpAeadKey => String::from("delete_otp_aead_key"),
+            Capability::Unknown => String::from("unknown"),
+        }
+    }
+}
+
+impl<T> From<T> for Capability
+where
+    T: AsRef<str>,
+{
+    fn from(s: T) -> Capability {
+        match s.as_ref() {
+            "get_opaque" => Capability::GetOpaque,
+            "put_opaque" => Capability::PutOpaque,
+            "put_authkey" => Capability::PutAuthKey,
+            "put_asymmetric" => Capability::PutAsymmetric,
+            "asymmetric_gen" => Capability::AsymmetricGen,
+            "asymmetric_sign_pkcs" => Capability::AsymmetricSignPkcs,
+            "asymmetric_sign_pss" => Capability::AsymmetricSignPss,
+            "asymmetric_sign_ecdsa" => Capability::AsymmetricSignEcdsa,
+            "asymmetric_sign_eddsa" => Capability::AsymmetricSignEddsa,
+            "asymmetric_decrypt_pkcs" => Capability::AsymmetricDecryptPkcs,
+            "asymmetric_decrypt_oaep" => Capability::AsymmetricDecryptOaep,
+            "asymmetric_decrypt_ecdh" => Capability::AsymmetricDecryptEcdh,
+            "export_wrapped" => Capability::ExportWrapped,
+            "import_wrapped" => Capability::ImportWrapped,
+            "put_wrapkey" => Capability::PutWrapkey,
+            "generate_wrapkey" => Capability::GenerateWrapkey,
+            "export_under_wrap" => Capability::ExportUnderWrap,
+            "put_option" => Capability::PutOption,
+            "get_option" => Capability::GetOption,
+            "get_randomness" => Capability::GetRandomness,
+            "put_hmackey" => Capability::PutHmackey,
+            "hmackey_generate" => Capability::HmackeyGenerate,
+            "hmac_data" => Capability::HmacData,
+            "hmac_verify" => Capability::HmacVerify,
+            "audit" => Capability::Audit,
+            "ssh_certify" => Capability::SshCertify,
+            "get_template" => Capability::GetTemplate,
+            "put_template" => Capability::PutTemplate,
+            "reset" => Capability::Reset,
+            "otp_decrypt" => Capability::OtpDecrypt,
+            "otp_aead_create" => Capability::OtpAeadCreate,
+            "otp_aead_random" => Capability::OtpAeadRandom,
+            "otp_aead_rewrap_from" => Capability::OtpAeadRewrapFrom,
+            "otp_aead_rewrap_to" => Capability::OtpAeadRewrapTo,
+            "attest" => Capability::Attest,
+            "put_otp_aead_key" => Capability::PutOtpAeadKey,
+            "generate_otp_aead_key" => Capability::GenerateOtpAeadKey,
+            "wrap_data" => Capability::WrapData,
+            "unwrap_data" => Capability::UnwrapData,
+            "delete_opaque" => Capability::DeleteOpaque,
+            "delete_authkey" => Capability::DeleteAuthkey,
+            "delete_asymmetric" => Capability::DeleteAsymmetric,
+            "delete_wrap_key" => Capability::DeleteWrapKey,
+            "delete_hmac_key" => Capability::DeleteHmacKey,
+            "delete_template" => Capability::DeleteTemplate,
+            "delete_otp_aead_key" => Capability::DeleteOtpAeadKey,
+            _ => Capability::Unknown,
         }
     }
 }


### PR DESCRIPTION
There are also some miscellaneous improvements in here that ended being necessary/useful for the rest of this PR:
* Don't go through libyubihsm for converting between `Domain`/`DomainParam`, it's easier just to do it by hand
* Remove some trait restrictions on `From` impls for various types and remove a bunch of allocations in the process